### PR TITLE
correct indentation

### DIFF
--- a/internal/test/resources.go
+++ b/internal/test/resources.go
@@ -312,7 +312,6 @@ func NewCryostatWithReportsScheduling() *operatorv1beta1.Cryostat {
 										Key:      "node",
 										Operator: corev1.NodeSelectorOpIn,
 										Values: []string{
-
 											"good",
 											"better",
 										},
@@ -322,39 +321,17 @@ func NewCryostatWithReportsScheduling() *operatorv1beta1.Cryostat {
 						},
 					},
 				},
-
-					PodAffinity: &corev1.PodAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-							NodeSelectorTerms: []corev1.NodeSelectorTerm{
-								{
-									MatchExpressions: []corev1.NodeSelectorRequirement{
-										{
-											Key:      "pod",
-											Operator: corev1.NodeSelectorOpIn,
-											Values: []string{
-
-												"good",
-												"better",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					PodAntiAffinity: &corev1.PodAntiAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-							NodeSelectorTerms: []corev1.NodeSelectorTerm{
-								{
-									MatchExpressions: []corev1.NodeSelectorRequirement{
-										{
-											Key:      "pod",
-											Operator: corev1.NodeSelectorOpIn,
-											Values: []string{
-
-												"bad",
-												"worse",
-											},
+				PodAffinity: &corev1.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "pod",
+										Operator: corev1.NodeSelectorOpIn,
+										Values: []string{
+											"good",
+											"better",
 										},
 									},
 								},
@@ -362,21 +339,38 @@ func NewCryostatWithReportsScheduling() *operatorv1beta1.Cryostat {
 						},
 					},
 				},
-
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "pod",
+										Operator: corev1.NodeSelectorOpIn,
+										Values: []string{
+											"bad",
+											"worse",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			Tolerations: []corev1.Toleration{
 				{
 					Key:      "node",
 					Operator: corev1.NodeSelectorOpIn,
 					Values: []string{
-
 						"good",
 						"better",
 					},
 				},
 			},
 		},
-			},
-		
+	}
+
 	return cr
 }
 


### PR DESCRIPTION
Hey John,

Here's a fix for the indentation. There are still some compile errors based on Pod(Anti)Affinity using different types compared to NodeAffinity. For Pod(Anti)Affinity, `RequiredDuringSchedulingIgnoredDuringExecution` is a `[]corev1.PodAffinityTerm`, while for NodeAffinity it is a `*corev1.NodeSelector`. The syntax is very similar but the APIs are slightly diferent, perhaps they were added at different times.

Toleration also has some subtle differences, the Operator field is type `corev1.TolerationOperator`. It only takes a single `Value` not `Values`. There is also an `Effect` field we could set as well.

It should at least be easier to fix these with the nesting sorted. We can discuss it at our next meeting.